### PR TITLE
refactor(posts): extract noise-tag filter to one shared util

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -42,7 +42,7 @@ const year = new Date().getFullYear();
     font-weight: 500;
     color: var(--color-text-muted);
     text-decoration: none;
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -120,8 +120,8 @@ const current = Astro.url.pathname;
     background: var(--color-text);
     width: 2rem;
     height: 2rem;
-    border-radius: 0.25rem;
-    transition: background-color 0.15s ease;
+    border-radius: var(--radius-xs);
+    transition: background-color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {
@@ -148,8 +148,8 @@ const current = Astro.url.pathname;
     color: var(--color-text-muted);
     letter-spacing: 0.01em;
     padding: 0.35rem 0.6rem;
-    border-radius: 0.3rem;
-    transition: color 0.15s ease, background-color 0.15s ease;
+    border-radius: var(--radius-sm);
+    transition: color var(--dur-fast) ease, background-color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {
@@ -182,9 +182,9 @@ const current = Astro.url.pathname;
     border: none;
     background: transparent;
     color: var(--color-text-muted);
-    border-radius: 0.3rem;
+    border-radius: var(--radius-sm);
     cursor: pointer;
-    transition: color 0.15s ease, background-color 0.15s ease;
+    transition: color var(--dur-fast) ease, background-color var(--dur-fast) ease;
     flex-shrink: 0;
     margin-left: 0.25rem;
   }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,11 @@
+// Tag values that come from the Ghost import flow (and historical
+// status markers) but should never render as a category chip.
+// `bea1fdf` cleaned them out of every committed post; this guard
+// stays so a future vault-sync or one-off re-import can't silently
+// reintroduce them.
+const NOISE_TAGS = new Set(['empty-coffee', 'published', 'draft', 'idea']);
+
+export function displayableTags(tags: readonly string[] | undefined): string[] {
+  if (!tags) return [];
+  return tags.filter(t => !NOISE_TAGS.has(t));
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import { site, heroSocials } from '../config/site';
 import { getCollection } from 'astro:content';
 import { Image } from 'astro:assets';
 import profileImg from '../assets/profile.jpg';
+import { displayableTags } from '../lib/posts';
 
 const allPosts = await getCollection('posts');
 const recentPosts = allPosts
@@ -92,8 +93,7 @@ const personJsonLd = {
           </div>
           <ol class="post-list">
             {recentPosts.map(post => {
-              const tags = post.data.tags
-                .filter(t => !['empty-coffee', 'published', 'draft', 'idea'].includes(t))
+              const tags = displayableTags(post.data.tags)
                 .slice(0, 1)
                 .map(t => t.replace(/-/g, ' '));
               return (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -249,7 +249,7 @@ const personJsonLd = {
     font-size: 0.875rem;
     font-weight: 500;
     color: var(--color-text-muted);
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {
@@ -305,7 +305,7 @@ const personJsonLd = {
     gap: 1rem;
     padding: 1rem 0;
     color: var(--color-text);
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
     align-items: start;
   }
 
@@ -322,7 +322,7 @@ const personJsonLd = {
   .post-thumb {
     width: 4.5rem;
     height: 4.5rem;
-    border-radius: 0.3rem;
+    border-radius: var(--radius-sm);
     overflow: hidden;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
@@ -334,7 +334,7 @@ const personJsonLd = {
     height: 100%;
     object-fit: cover;
     display: block;
-    transition: transform 0.25s ease;
+    transition: transform var(--dur-base) ease;
   }
 
   .post-body {
@@ -382,7 +382,7 @@ const personJsonLd = {
     font-weight: 500;
     font-size: 0.925rem;
     line-height: 1.4;
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
     margin: 0;
   }
 
@@ -460,7 +460,7 @@ const personJsonLd = {
     font-size: 1rem;
     color: var(--color-accent);
     align-self: end;
-    transition: transform 0.2s ease;
+    transition: transform var(--dur-base) ease;
   }
 
   @media (hover: hover) {
@@ -482,7 +482,7 @@ const personJsonLd = {
     color: var(--color-accent);
     font-weight: 500;
     font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {

--- a/src/pages/photography.astro
+++ b/src/pages/photography.astro
@@ -203,37 +203,6 @@ const collections = [...collectionMap.entries()].sort(
 </Base>
 
 <style>
-  .page-header {
-    padding: 4.5rem 0 3rem;
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .page-eyebrow {
-    font-size: 0.75rem;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-text-muted);
-    margin: 0 0 0.75rem;
-  }
-
-  .page-title {
-    font-size: clamp(2.75rem, 6vw, 4.25rem);
-    font-weight: 700;
-    margin: 0 0 1rem;
-    letter-spacing: -0.025em;
-    line-height: 1;
-  }
-
-  .page-desc {
-    font-size: 1rem;
-    color: var(--color-text-muted);
-    max-width: 480px;
-    margin: 0;
-    line-height: 1.65;
-    font-weight: 300;
-  }
-
   .empty-state {
     padding: 4rem 0;
     color: var(--color-text-muted);

--- a/src/pages/photography.astro
+++ b/src/pages/photography.astro
@@ -246,7 +246,7 @@ const collections = [...collectionMap.entries()].sort(
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     text-decoration: none;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color var(--dur-base) ease, box-shadow var(--dur-base) ease;
   }
 
   @media (hover: hover) {
@@ -322,7 +322,7 @@ const collections = [...collectionMap.entries()].sort(
     margin-top: 0.5rem;
     opacity: 0;
     transform: translateX(-4px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
+    transition: opacity var(--dur-base) ease, transform var(--dur-base) ease;
   }
 
   @media (hover: hover) {
@@ -356,7 +356,7 @@ const collections = [...collectionMap.entries()].sort(
     height: 100%;
     display: block;
     object-fit: cover;
-    transition: transform 0.5s ease;
+    transition: transform var(--dur-slow) ease;
   }
 
   @media (hover: hover) {
@@ -374,7 +374,7 @@ const collections = [...collectionMap.entries()].sort(
     justify-content: flex-end;
     padding: 1rem;
     opacity: 0;
-    transition: opacity 0.25s ease;
+    transition: opacity var(--dur-base) ease;
     pointer-events: none;
   }
 

--- a/src/pages/photography/[slug].astro
+++ b/src/pages/photography/[slug].astro
@@ -226,7 +226,7 @@ const jsonLd = {
     height: auto;
     object-fit: contain;
     display: block;
-    box-shadow: 0 8px 48px rgba(0, 0, 0, 0.18);
+    box-shadow: var(--shadow-photo);
   }
 
   /* ── Metadata panel ── */
@@ -250,7 +250,7 @@ const jsonLd = {
     letter-spacing: 0.08em;
     color: var(--color-text-muted);
     text-decoration: none;
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {
@@ -316,7 +316,7 @@ const jsonLd = {
   /* Map */
   .photo-map {
     height: 200px;
-    border-radius: 0.5rem;
+    border-radius: var(--radius-lg);
     overflow: hidden;
     border: 1px solid var(--color-border);
   }
@@ -348,7 +348,7 @@ const jsonLd = {
     font-size: 0.8rem;
     color: var(--color-text-muted);
     text-decoration: none;
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
     line-height: 1.4;
   }
 

--- a/src/pages/photography/collection/[slug].astro
+++ b/src/pages/photography/collection/[slug].astro
@@ -171,7 +171,7 @@ const { name, photos } = Astro.props;
     letter-spacing: 0.08em;
     color: var(--color-text-muted);
     text-decoration: none;
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {
@@ -207,7 +207,7 @@ const { name, photos } = Astro.props;
     height: 100%;
     display: block;
     object-fit: cover;
-    transition: transform 0.5s ease;
+    transition: transform var(--dur-slow) ease;
   }
 
   @media (hover: hover) {
@@ -225,7 +225,7 @@ const { name, photos } = Astro.props;
     justify-content: flex-end;
     padding: 1rem;
     opacity: 0;
-    transition: opacity 0.25s ease;
+    transition: opacity var(--dur-base) ease;
     pointer-events: none;
   }
 

--- a/src/pages/photography/collection/[slug].astro
+++ b/src/pages/photography/collection/[slug].astro
@@ -141,9 +141,20 @@ const { name, photos } = Astro.props;
 </Base>
 
 <style>
-  .page-header {
-    padding: 4.5rem 0 3rem;
-    border-bottom: 1px solid var(--color-border);
+  /* Collection page tweaks the shared .page-header rules:
+     accent-colored eyebrow, tighter title margin, smaller desc
+     without the max-width cap. Base rules live in global.css. */
+  .page-eyebrow {
+    color: var(--color-accent);
+  }
+
+  .page-title {
+    margin: 0 0 0.5rem;
+  }
+
+  .page-desc {
+    font-size: 0.9rem;
+    max-width: none;
   }
 
   .breadcrumb {
@@ -167,30 +178,6 @@ const { name, photos } = Astro.props;
     .breadcrumb__link:hover {
       color: var(--color-accent);
     }
-  }
-
-  .page-eyebrow {
-    font-size: 0.75rem;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-accent);
-    margin: 0 0 0.75rem;
-  }
-
-  .page-title {
-    font-size: clamp(2.75rem, 6vw, 4.25rem);
-    font-weight: 700;
-    margin: 0 0 0.5rem;
-    letter-spacing: -0.025em;
-    line-height: 1;
-  }
-
-  .page-desc {
-    font-size: 0.9rem;
-    color: var(--color-text-muted);
-    margin: 0;
-    font-weight: 300;
   }
 
   .gallery-wrapper {

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -4,6 +4,7 @@ import Nav from '../../components/Nav.astro';
 import Footer from '../../components/Footer.astro';
 import { getCollection } from 'astro:content';
 import type { GetStaticPaths } from 'astro';
+import { displayableTags } from '../../lib/posts';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const all = await getCollection('posts');
@@ -59,8 +60,7 @@ const isFirstPage = page.currentPage === 1;
           <h2 class="posts__year">{year}</h2>
           <ol class="posts__list">
             {byYear.get(year)!.map(post => {
-              const tag = post.data.tags
-                .filter(t => !['empty-coffee', 'published', 'draft', 'idea'].includes(t))
+              const tag = displayableTags(post.data.tags)
                 .map(t => t.replace(/-/g, ' '))[0];
               return (
                 <li class="posts__item">

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -116,65 +116,6 @@ const isFirstPage = page.currentPage === 1;
     padding: 0 0 5rem;
   }
 
-  .page-header {
-    padding: 4.5rem 0 3rem;
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .page-eyebrow-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin: 0 0 0.75rem;
-  }
-
-  .page-eyebrow {
-    font-size: 0.75rem;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-text-muted);
-    margin: 0;
-  }
-
-  .page-rss {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-accent);
-    transition: color 0.15s ease;
-  }
-
-  @media (hover: hover) {
-    .page-rss:hover {
-      color: var(--color-accent-hover);
-    }
-  }
-
-  .page-title {
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: clamp(2.75rem, 6vw, 4.25rem);
-    line-height: 1;
-    letter-spacing: -0.025em;
-    margin: 0 0 1rem;
-    color: var(--color-text);
-  }
-
-  .page-desc {
-    font-size: 1rem;
-    color: var(--color-text-muted);
-    max-width: 480px;
-    margin: 0;
-    line-height: 1.65;
-    font-weight: 300;
-  }
-
   .posts__year-group {
     margin-top: 3rem;
   }
@@ -336,10 +277,6 @@ const isFirstPage = page.currentPage === 1;
   @media (max-width: 640px) {
     .posts {
       padding: 0 0 3rem;
-    }
-
-    .page-header {
-      padding: 3rem 0 2rem;
     }
 
     .posts__link {

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -152,7 +152,7 @@ const isFirstPage = page.currentPage === 1;
     padding: 1rem 0;
     color: var(--color-text);
     align-items: start;
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {
@@ -168,7 +168,7 @@ const isFirstPage = page.currentPage === 1;
   .posts__thumb {
     width: 4.5rem;
     height: 4.5rem;
-    border-radius: 0.3rem;
+    border-radius: var(--radius-sm);
     overflow: hidden;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
@@ -180,7 +180,7 @@ const isFirstPage = page.currentPage === 1;
     height: 100%;
     object-fit: cover;
     display: block;
-    transition: transform 0.25s ease;
+    transition: transform var(--dur-base) ease;
   }
 
   .posts__meta {
@@ -221,7 +221,7 @@ const isFirstPage = page.currentPage === 1;
     font-size: 1rem;
     line-height: 1.4;
     margin: 0 0 0.25rem;
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
     color: var(--color-text);
   }
 
@@ -257,7 +257,7 @@ const isFirstPage = page.currentPage === 1;
     font-size: 0.85rem;
     font-weight: 500;
     color: var(--color-accent);
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -3,6 +3,7 @@ import Base from '../../layouts/Base.astro';
 import Nav from '../../components/Nav.astro';
 import Footer from '../../components/Footer.astro';
 import { getCollection, render } from 'astro:content';
+import { displayableTags } from '../../lib/posts';
 
 export async function getStaticPaths() {
   const all = await getCollection('posts');
@@ -95,13 +96,11 @@ const articleJsonLd = {
         <Content />
       </div>
 
-      {tags.length > 0 && (
+      {displayableTags(tags).length > 0 && (
         <ul class="post__tags" aria-label="tags">
-          {tags
-            .filter(t => !['empty-coffee', 'published', 'draft', 'idea'].includes(t))
-            .map(t => (
-              <li class="post__tag">{t.replace(/-/g, ' ')}</li>
-            ))}
+          {displayableTags(tags).map(t => (
+            <li class="post__tag">{t.replace(/-/g, ' ')}</li>
+          ))}
         </ul>
       )}
 

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -143,7 +143,7 @@ const articleJsonLd = {
 
   .post__hero {
     margin: 0;
-    border-radius: 0.4rem;
+    border-radius: var(--radius-md);
     overflow: hidden;
     background: var(--color-surface);
   }
@@ -174,7 +174,7 @@ const articleJsonLd = {
   .post__back {
     color: var(--color-accent);
     font-weight: 500;
-    transition: color 0.15s ease;
+    transition: color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {
@@ -237,7 +237,7 @@ const articleJsonLd = {
   .post__body :global(a) {
     color: var(--color-accent);
     border-bottom: 1px solid color-mix(in oklab, var(--color-accent) 35%, transparent);
-    transition: border-color 0.15s ease, color 0.15s ease;
+    transition: border-color var(--dur-fast) ease, color var(--dur-fast) ease;
   }
 
   @media (hover: hover) {
@@ -286,7 +286,7 @@ const articleJsonLd = {
     max-width: 100%;
     height: auto;
     margin: 2rem auto;
-    border-radius: 0.25rem;
+    border-radius: var(--radius-xs);
   }
 
   .post__body :global(figure) {
@@ -332,14 +332,14 @@ const articleJsonLd = {
     font-size: 0.875em;
     background: var(--color-surface);
     padding: 0.1em 0.35em;
-    border-radius: 0.2rem;
+    border-radius: var(--radius-xs);
     border: 1px solid var(--color-border);
   }
 
   .post__body :global(pre) {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 0.4rem;
+    border-radius: var(--radius-md);
     padding: 1rem 1.25rem;
     margin: 1.5rem 0;
     overflow-x: auto;
@@ -415,9 +415,9 @@ const articleJsonLd = {
     padding: 1rem;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 0.4rem;
+    border-radius: var(--radius-md);
     color: var(--color-text);
-    transition: border-color 0.15s ease, transform 0.15s ease;
+    transition: border-color var(--dur-fast) ease, transform var(--dur-fast) ease;
   }
 
   .post__pager-link--next {

--- a/src/pages/posts/[slug].md.ts
+++ b/src/pages/posts/[slug].md.ts
@@ -1,5 +1,6 @@
 import type { APIRoute, GetStaticPaths } from 'astro';
 import { getCollection } from 'astro:content';
+import { displayableTags } from '../../lib/posts';
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const posts = await getCollection('posts');
@@ -25,9 +26,7 @@ export const GET: APIRoute = ({ props }) => {
   const dateISO = publish_date.toISOString().split('T')[0];
   const readMin = word_count ? Math.max(1, Math.round(word_count / 220)) : null;
 
-  const cleanTags = tags
-    .filter((t: string) => !['empty-coffee', 'published', 'draft', 'idea'].includes(t))
-    .map((t: string) => t.replace(/-/g, ' '));
+  const cleanTags = displayableTags(tags).map(t => t.replace(/-/g, ' '));
 
   const metaParts = [`Published ${dateISO}`];
   if (readMin) metaParts.push(`${readMin} min read`);

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,6 +1,7 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import { site } from '../config/site';
+import { displayableTags } from '../lib/posts';
 import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = async (context) => {
@@ -30,9 +31,7 @@ export const GET: APIRoute = async (context) => {
         pubDate: post.data.publish_date!,
         link,
         author: post.data.author,
-        categories: post.data.tags.filter(
-          t => !['empty-coffee', 'published', 'draft', 'idea'].includes(t),
-        ),
+        categories: displayableTags(post.data.tags),
         ...(enclosure ? { enclosure } : {}),
       };
     }),

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -167,38 +167,6 @@ import { spotlight, experience, talks, skillGroups } from '../data/work';
 </Base>
 
 <style>
-  .page-header {
-    padding: 4.5rem 0 3rem;
-    border-bottom: 1px solid var(--color-border);
-    margin-bottom: 0;
-  }
-
-  .page-eyebrow {
-    font-size: 0.75rem;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-text-muted);
-    margin: 0 0 0.75rem;
-  }
-
-  .page-title {
-    font-size: clamp(2.75rem, 6vw, 4.25rem);
-    font-weight: 700;
-    margin: 0 0 1rem;
-    letter-spacing: -0.025em;
-    line-height: 1;
-  }
-
-  .page-desc {
-    font-size: 1rem;
-    color: var(--color-text-muted);
-    max-width: 480px;
-    margin: 0;
-    line-height: 1.65;
-    font-weight: 300;
-  }
-
   .work-section {
     padding: 2.75rem 0;
     border-bottom: 1px solid var(--color-border);
@@ -517,10 +485,6 @@ import { spotlight, experience, talks, skillGroups } from '../data/work';
   }
 
   @media (max-width: 600px) {
-    .page-header {
-      padding: 3rem 0 2rem;
-    }
-
     .job__header {
       flex-direction: column;
       gap: 0.25rem;

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -311,7 +311,7 @@ import { spotlight, experience, talks, skillGroups } from '../data/work';
     color: var(--color-text);
     padding: 1.1rem 1.25rem;
     border: 1px solid var(--color-border);
-    border-radius: 0.4rem;
+    border-radius: var(--radius-md);
   }
 
   .talk-type {
@@ -406,10 +406,10 @@ import { spotlight, experience, talks, skillGroups } from '../data/work';
     padding: 1.5rem;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 0.4rem;
+    border-radius: var(--radius-md);
     color: var(--color-text);
     text-decoration: none;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color var(--dur-base) ease, box-shadow var(--dur-base) ease;
     position: relative;
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -309,6 +309,81 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* ============================================================
+   PAGE HEADER — shared across /work/, /photography/, /posts/,
+   /photography/collection/<slug>/. Per-page scoped styles can
+   override individual rules (e.g. collection page's smaller
+   page-desc and accent-colored eyebrow).
+   ============================================================ */
+.page-header {
+  padding: 4.5rem 0 3rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.page-eyebrow-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0 0 0.75rem;
+}
+
+.page-eyebrow {
+  font-size: 0.75rem;
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-eyebrow);
+  color: var(--color-text-muted);
+  margin: 0 0 0.75rem;
+}
+
+.page-eyebrow-row .page-eyebrow {
+  margin: 0;
+}
+
+.page-title {
+  font-family: var(--font-display);
+  font-size: var(--fs-4xl);
+  font-weight: var(--weight-bold);
+  letter-spacing: var(--tracking-tight);
+  line-height: 1;
+  margin: 0 0 1rem;
+  color: var(--color-text);
+}
+
+.page-desc {
+  font-size: 1rem;
+  color: var(--color-text-muted);
+  font-weight: var(--weight-light);
+  line-height: 1.65;
+  max-width: 480px;
+  margin: 0;
+}
+
+.page-rss {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-eyebrow);
+  color: var(--color-accent);
+  transition: color var(--dur-fast) ease;
+}
+
+@media (hover: hover) {
+  .page-rss:hover {
+    color: var(--color-accent-hover);
+  }
+}
+
+@media (max-width: 640px) {
+  .page-header {
+    padding: 3rem 0 2rem;
+  }
+}
+
+/* ============================================================
    ANIMATION UTILITIES
    ============================================================ */
 .animate-fade-up {


### PR DESCRIPTION
Five callsites had the same `['empty-coffee', 'published', 'draft',
'idea'].includes(t)` filter inlined. After bea1fdf cleaned the noise
tags out of every committed post, the filter is purely defensive,
but worth keeping for any future vault-sync or one-off re-import
that could reintroduce them.

* New: src/lib/posts.ts exports `displayableTags()`.
* Swap callsites: index.astro, posts/[...page].astro, posts/[slug].astro,
  posts/[slug].md.ts, rss.xml.ts.

Build and tests unchanged (209 pass; the rss.test.ts negative
assertion that noise tags never reach <category> validates the new
util indirectly).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>