### PR TITLE
fix(workers): handle /robots.txt, /sitemap.xml, /favicon.ico explicitly

### DIFF
--- a/tests/unit/redirect.test.ts
+++ b/tests/unit/redirect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveTarget } from '../../workers/empty-coffee-redirects/src/redirect';
+import { resolveTarget, ROBOTS_TXT } from '../../workers/empty-coffee-redirects/src/redirect';
 
 const SITE = 'https://mike.lapidak.is';
 
@@ -71,6 +71,32 @@ describe('empty.coffee redirect resolution', () => {
         expect(resolveTarget(path)).toBe(`${SITE}/rss.xml`);
       },
     );
+  });
+
+  describe('sitemap paths', () => {
+    it.each(['/sitemap.xml', '/sitemap-index.xml', '/sitemap-0.xml'])(
+      '%s → /sitemap-index.xml',
+      (path) => {
+        expect(resolveTarget(path)).toBe(`${SITE}/sitemap-index.xml`);
+      },
+    );
+  });
+
+  describe('favicon / apple-touch-icon', () => {
+    it('/favicon.ico → /favicon.ico (path preserved, not wrapped as /posts/)', () => {
+      expect(resolveTarget('/favicon.ico')).toBe(`${SITE}/favicon.ico`);
+    });
+    it('/apple-touch-icon.png → /apple-touch-icon.png', () => {
+      expect(resolveTarget('/apple-touch-icon.png')).toBe(`${SITE}/apple-touch-icon.png`);
+    });
+  });
+
+  describe('robots.txt content', () => {
+    it('allows crawling and points at the canonical sitemap', () => {
+      expect(ROBOTS_TXT).toContain('User-agent: *');
+      expect(ROBOTS_TXT).toContain('Allow: /');
+      expect(ROBOTS_TXT).toContain(`Sitemap: ${SITE}/sitemap-index.xml`);
+    });
   });
 
   describe('multi-segment paths fall back to the posts index', () => {

--- a/workers/empty-coffee-redirects/src/index.ts
+++ b/workers/empty-coffee-redirects/src/index.ts
@@ -1,14 +1,30 @@
 // Cloudflare Worker bound to empty.coffee/*. Issues 301 redirects to
-// the canonical mike.lapidak.is URLs computed in ./redirect.ts.
+// the canonical mike.lapidak.is URLs computed in ./redirect.ts. Serves
+// /robots.txt directly (200) so crawlers can read it without following
+// a cross-host chain.
 //
 // Deploy:
 //   cd workers/empty-coffee-redirects && npx wrangler deploy
 
-import { resolveTarget } from './redirect';
+import { resolveTarget, ROBOTS_TXT } from './redirect';
 
 export default {
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
+
+    // /robots.txt is served inline (200) so Google's Change of Address
+    // tool and other crawlers can read crawl directives without a
+    // cross-host redirect getting in the way.
+    if (url.pathname.replace(/\/$/, '').toLowerCase() === '/robots.txt') {
+      return new Response(ROBOTS_TXT, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'Cache-Control': 'public, max-age=3600',
+        },
+      });
+    }
+
     const target = resolveTarget(url.pathname);
     return Response.redirect(target, 301);
   },

--- a/workers/empty-coffee-redirects/src/redirect.ts
+++ b/workers/empty-coffee-redirects/src/redirect.ts
@@ -12,18 +12,26 @@ const SLUG_REMAP: Record<string, string> = {
 };
 
 const FEED_PATHS = new Set(['/rss', '/rss.xml', '/feed', '/feed.xml']);
+const SITEMAP_PATHS = new Set(['/sitemap.xml', '/sitemap-index.xml', '/sitemap-0.xml']);
+const FAVICON_PATHS = new Set(['/favicon.ico', '/apple-touch-icon.png']);
 
 /**
  * Resolve the canonical mike.lapidak.is URL for a given empty.coffee
  * request path. Always returns a fully-qualified https URL.
  *
  * Rules:
- *   /                        → https://mike.lapidak.is/
- *   /<slug>/                 → https://mike.lapidak.is/posts/<slug>/
- *                              (with the cacheing → caching remap)
- *   /rss/, /rss.xml, /feed   → https://mike.lapidak.is/rss.xml
- *   /tag/x, /author/x, ...   → https://mike.lapidak.is/posts/
- *   anything else            → https://mike.lapidak.is/posts/
+ *   /                          → https://mike.lapidak.is/
+ *   /<slug>/                   → https://mike.lapidak.is/posts/<slug>/
+ *                                (with the cacheing → caching remap)
+ *   /rss/, /rss.xml, /feed     → https://mike.lapidak.is/rss.xml
+ *   /sitemap.xml, /sitemap-*   → https://mike.lapidak.is/sitemap-index.xml
+ *   /favicon.ico, /apple-touch → equivalent at https://mike.lapidak.is
+ *   /tag/x, /author/x, ...     → https://mike.lapidak.is/posts/
+ *   anything else              → https://mike.lapidak.is/posts/
+ *
+ * `/robots.txt` is served as a 200 directly by the Worker (see
+ * index.ts) — it's not a redirect — so crawlers can read it without
+ * following the chain to another host.
  *
  * Trailing slashes and repeated slashes are normalised. Query strings
  * are dropped (they were Ghost-era tracking like ?ref=empty.coffee).
@@ -42,6 +50,17 @@ export function resolveTarget(pathname: string): string {
     return `${SITE}/rss.xml`;
   }
 
+  // Sitemap paths → canonical sitemap-index.xml on the new site.
+  if (SITEMAP_PATHS.has(lowered)) {
+    return `${SITE}/sitemap-index.xml`;
+  }
+
+  // Favicon / apple-touch-icon → matching path on the new site
+  // (rather than getting wrapped up as a /posts/ slug).
+  if (FAVICON_PATHS.has(lowered)) {
+    return `${SITE}${lowered}`;
+  }
+
   // Strip the leading slash for slug analysis.
   const stripped = lowered.replace(/^\/+/, '');
 
@@ -55,3 +74,14 @@ export function resolveTarget(pathname: string): string {
   const slug = SLUG_REMAP[stripped] ?? stripped;
   return `${SITE}/posts/${slug}/`;
 }
+
+/**
+ * robots.txt content served directly by the Worker (200 response, no
+ * redirect) so crawlers — including Google's Change of Address tool —
+ * can read it without following any cross-host redirect chain.
+ */
+export const ROBOTS_TXT = `User-agent: *
+Allow: /
+
+Sitemap: ${SITE}/sitemap-index.xml
+`;


### PR DESCRIPTION
## Summary

Empty.coffee was treating special static paths (`/robots.txt`, `/sitemap.xml`, `/favicon.ico`, `/apple-touch-icon.png`) as post slugs and 301'ing them to broken `/posts/<file>/` URLs on mike.lapidak.is. Google Search Console's Change of Address validation tool fetches `/robots.txt` first to confirm crawl permission — got the broken redirect, bailed.

- **`/robots.txt`** — now served inline as a 200 with `User-agent: * \n Allow: /` and a pointer to `mike.lapidak.is/sitemap-index.xml`. No cross-host redirect chain for crawlers to follow.
- **`/sitemap.xml`, `/sitemap-index.xml`, `/sitemap-0.xml`** — 301 to `mike.lapidak.is/sitemap-index.xml` (the canonical sitemap Astro emits).
- **`/favicon.ico`, `/apple-touch-icon.png`** — 301 to the matching path on mike.lapidak.is (not wrapped under `/posts/`).
- **6 new test cases** in `tests/unit/redirect.test.ts` covering the new behaviors. Suite total for the redirect Worker is now 26 (was 20).

**Already deployed** (Worker version `80895514`) and verified live via curl. This PR brings the repo source back in sync with what's running.

## Test plan

- [x] `npx vitest run tests/unit/redirect.test.ts` — 26/26 passing
- [x] Live curl on the deployed Worker:
  - [x] `https://empty.coffee/robots.txt` → 200 with crawl-allowed body
  - [x] `https://empty.coffee/favicon.ico` → 301 to `https://mike.lapidak.is/favicon.ico`
  - [x] `https://empty.coffee/sitemap.xml` → 301 to `https://mike.lapidak.is/sitemap-index.xml`
  - [x] Existing redirects (root, post slugs, slug remap, feed paths, multi-segment) all still working
- [ ] Re-run Google Search Console Change of Address validation after their checker queue refreshes (currently cached on the old probe)

## Post-merge

Nothing required — Worker is already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)