### PR TITLE
content: rewrite bio + work page in personal voice, add /work.md

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,6 +5,10 @@
   X-Robots-Tag: noindex
   Cache-Control: public, max-age=3600
 
+/work.md
+  X-Robots-Tag: noindex
+  Cache-Control: public, max-age=3600
+
 # llms.txt and any future llms-* files: text-format LLM hints.
 /llms.txt
   X-Robots-Tag: noindex

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,9 +1,9 @@
 export const site = {
   name: 'Mike Lapidakis',
   url: 'https://mike.lapidak.is',
-  description: 'Engineering leader, photographer, and tinkerer based in the Pacific Northwest.',
+  description: 'Builder, photographer, dad of two boys in Denver. Writing on homelab, self-hosted services, and the tools I use to think.',
   role: 'Security & Networking SA Leader · AWS · Denver, CO',
-  bio: "I've spent 10 years at AWS, the last 6 building and leading specialist teams across security, networking, and generative AI. I still get into the weeds when it matters, and I build things meant to last. Dad, photographer, perpetual tinkerer.",
+  bio: "Builder, photographer, dad of two boys. I tinker with software and the homelab, ride gravel when I can, and write about what I'm making. Denver. Day job at AWS.",
 };
 
 export const socials = [

--- a/src/data/work.ts
+++ b/src/data/work.ts
@@ -37,7 +37,7 @@ export const experience = [
     role: 'Senior Manager, Security & Networking Specialist SAs',
     period: '2025 – present',
     location: 'Denver, CO',
-    description: 'Leading a team of 19 Security and Networking Specialist Solutions Architects across North America, including one manager. Split between team development, helping customers work through complex architecture decisions, and partnering across AWS on how we go to market in security and networking.',
+    description: 'Lead a team of Security and Networking specialist solutions architects for AWS\'s Global Accounts. Team is distributed across the US and Canada, densest in Seattle. Days are split between team development, helping customers work through complex architecture decisions, and partnering across AWS on how we go to market in these domains.',
     tags: ['Security', 'Networking', 'Team Leadership'],
   },
   {
@@ -45,7 +45,7 @@ export const experience = [
     role: 'Senior Manager, Specialist Solutions Architects',
     period: '2020 – 2025',
     location: 'Denver, CO',
-    description: 'Spent five years building specialist SA teams across Security, Networking, Resilience, Migration, and Generative AI for AWS\'s largest enterprise accounts. Grew the org from 7 to over 35, hiring across multiple technical domains. Stepped in as interim leader for a 50-person organization during a director transition, keeping things moving while filling 8 open roles. Co-led the Generative AI Security Scoping Matrix, which became an AWS product at re:Inforce 2024. Promoted three times; tried to pay it forward and promoted six team members along the way. Amazon Bar Raiser.',
+    description: 'Spent five years building specialist SA teams across Security, Networking, Resilience, Migration, and Generative AI for AWS\'s largest enterprise accounts. Grew the org from 7 to over 35, hiring across multiple technical domains. Stepped in as interim leader for the broader organization during a leadership transition. Co-authored the Generative AI Security Scoping Matrix, which became an AWS product at re:Inforce 2024 and the basis of the field enablement curriculum on GenAI scoping. Promoted three times; promoted six team members along the way. Amazon Bar Raiser.',
     tags: ['Org Design', 'Hiring & Development', 'Security', 'Networking', 'GenAI', 'Bar Raiser'],
   },
   {
@@ -53,7 +53,7 @@ export const experience = [
     role: 'Senior Solutions Architect, Global Accounts',
     period: '2019 – 2020',
     location: 'Denver, CO',
-    description: 'Mentored emerging Solutions Architects and pioneered the Migration SA specialty role within Global Accounts, establishing repeatable migration frameworks for AWS\'s largest enterprise customers. Led technical enablement for major telecommunications providers and oversaw large-scale server migration programs spanning 70+ global clients.',
+    description: 'Mentored emerging solutions architects and pioneered the Migration SA specialty within Global Accounts, building repeatable migration frameworks for AWS\'s largest enterprise customers. Led technical enablement across major telecommunications and life-sciences customers; oversaw large-scale enterprise migration programs across 70+ global clients.',
     tags: ['Enterprise Migrations', 'Telecommunications', 'Technical Enablement', 'Mentorship'],
   },
   {
@@ -61,7 +61,7 @@ export const experience = [
     role: 'Senior Solutions Architect, Enterprise Accounts',
     period: '2016 – 2019',
     location: 'Houston, TX',
-    description: 'Architected enterprise data lake solutions on Amazon Redshift and drove AWS adoption across the Houston enterprise market. Grew AWS revenue 400% at a primary account within two years through deep technical enablement. Presented at AWS re:Invent in 2017 and 2018. Organized and led the AWS Houston Area User Group.',
+    description: 'Architected enterprise data lake solutions on Amazon Redshift and grew AWS adoption across the Houston enterprise market. Hit 400% revenue growth at a primary account within two years through hands-on technical enablement. Presented at AWS re:Invent in 2017 and 2018. Organized and led the AWS Houston Area User Group.',
     tags: ['Enterprise Architecture', 'Data & Analytics', 'Pre-Sales', 'Community Leadership'],
   },
   {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,7 +34,7 @@ const personJsonLd = {
 
 <Base
   title="Mike Lapidakis"
-  description="10 years at AWS building and leading specialist teams across security, networking, and generative AI. Based in Denver, CO."
+  description={site.description}
 >
   <script type="application/ld+json" set:html={JSON.stringify(personJsonLd)} />
   <Nav />

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -22,7 +22,7 @@ export const GET: APIRoute = async () => {
 
   const out = `# Mike Lapidakis
 
-> Personal site for Mike Lapidakis, a Senior Manager at AWS leading Security & Networking Specialist Solutions Architects across North America. Based in Denver, CO. The site covers professional background (work, publications, talks), long-form writing on homelab and self-hosted services, and a photography portfolio shot on a Leica Q3.
+> Personal site for Mike Lapidakis, a Senior Manager at AWS leading Security & Networking Specialist Solutions Architects across North America. Based in Denver, CO. The site covers professional background (work, publications, talks), long-form writing on homelab and self-hosted services, and a photography portfolio.
 
 Mike has spent ten years at AWS, the last six building and leading specialist teams across security, networking, resilience, migration, and generative AI. He co-authored the AWS Generative AI Security Scoping Matrix and the Agentic AI Security Scoping Matrix, and presents regularly at AWS re:Inforce and re:Invent. Writing originally lived at empty.coffee and has been consolidated to this site. Photography also at glass.photo/lap.
 
@@ -33,7 +33,7 @@ This site is a static Astro build. All content is public and may be referenced o
 - [Home](${SITE}/): Hero, recent writing, and entry points to Photography and Work.
 - [Writing](${SITE}/posts/): All long-form posts, grouped by year. Topics: homelab, self-hosted services, AWS, photography workflow, and the tools used to think.
 - [Photography](${SITE}/photography): Justified-row grid of street, travel, and landscape photographs with collection stacks.
-- [Work](${SITE}/work): Career history at AWS, Equinix, EPMA, and Parker Hannifin; spotlight publications and conference talks; skill groups across leadership, technical domains, cloud, and compliance.
+- [Work](${SITE}/work): Career history at AWS, Equinix, EPMA, and Parker Hannifin; spotlight publications and conference talks; skill groups across leadership, technical domains, cloud, and compliance. Also available as raw markdown at [${SITE}/work.md](${SITE}/work.md).
 
 ## Writing
 
@@ -54,6 +54,7 @@ ${publicationLines.join('\n')}
 
 ## Optional
 
+- [Work as markdown](${SITE}/work.md): Background, experience, publications, talks, and skills as plain markdown.
 - [Sitemap](${SITE}/sitemap-index.xml): Full XML sitemap for the site.
 - [RSS feed](${SITE}/rss.xml): RSS 2.0 feed of all published writing.
 - [robots.txt](${SITE}/robots.txt): Crawler directives.

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -3,13 +3,52 @@ import Base from '../layouts/Base.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import { spotlight, experience, talks, skillGroups } from '../data/work';
+import { socials } from '../config/site';
+
+const profileJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'ProfilePage',
+  mainEntity: {
+    '@type': 'Person',
+    name: 'Mike Lapidakis',
+    url: 'https://mike.lapidak.is/work',
+    jobTitle: 'Senior Manager, Security & Networking Specialist Solutions Architects',
+    worksFor: {
+      '@type': 'Organization',
+      name: 'Amazon Web Services',
+      url: 'https://aws.amazon.com',
+    },
+    alumniOf: {
+      '@type': 'CollegeOrUniversity',
+      name: 'University of Toledo',
+      url: 'https://www.utoledo.edu',
+    },
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: 'Denver',
+      addressRegion: 'CO',
+      addressCountry: 'US',
+    },
+    knowsAbout: [
+      'Cloud Security Architecture',
+      'Network Architecture',
+      'Generative AI Security',
+      'Enterprise Cloud Migration',
+      'Solutions Architecture Leadership',
+      'Amazon Web Services',
+    ],
+    sameAs: socials.map(s => s.href),
+  },
+};
 ---
 
 <Base
   title="Work"
-  description="Mike Lapidakis · engineering leader, AWS, distributed systems."
+  description="Mike Lapidakis · Senior Manager of Security & Networking Specialist SAs at AWS. Background, talks, writing, and ways to get in touch."
 >
   <Nav />
+
+  <script type="application/ld+json" set:html={JSON.stringify(profileJsonLd)} />
 
   <main>
     <section class="page-header">
@@ -17,10 +56,10 @@ import { spotlight, experience, talks, skillGroups } from '../data/work';
         <p class="page-eyebrow">Background</p>
         <h1 class="page-title display">Work</h1>
         <p class="page-desc">
-          I've spent the last decade building and leading specialist teams at AWS:
-          growing organizations, stepping in during leadership transitions, and
-          developing frameworks that outlast the moment. Currently leading Security
-          &amp; Networking SAs across North America.
+          I lead a team of specialist solutions architects at AWS covering Security
+          and Networking for our largest customers. Most days are some mix of team
+          development, untangling customer architecture decisions, and figuring out
+          where the org should invest next. Builder by inclination.
         </p>
       </div>
     </section>

--- a/src/pages/work.md.ts
+++ b/src/pages/work.md.ts
@@ -1,0 +1,100 @@
+import type { APIRoute } from 'astro';
+import { spotlight, experience, talks, skillGroups } from '../data/work';
+import { socials } from '../config/site';
+
+export const GET: APIRoute = () => {
+  const lines: string[] = [];
+
+  lines.push('# Mike Lapidakis · Work');
+  lines.push('');
+  lines.push('> Senior Manager of Security & Networking Specialist Solutions Architects at AWS, based in Denver, CO. Background, talks, and writing.');
+  lines.push('');
+  lines.push('Source: https://mike.lapidak.is/work');
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  lines.push('## Now');
+  lines.push('');
+  lines.push('I lead a team of specialist solutions architects at AWS covering Security and Networking for our largest customers. Most days are some mix of team development, untangling customer architecture decisions, and figuring out where the org should invest next. Builder by inclination.');
+  lines.push('');
+
+  lines.push('## Spotlight');
+  lines.push('');
+  for (const item of spotlight) {
+    lines.push(`### ${item.title}`);
+    lines.push('');
+    lines.push(`*${item.type} · ${item.meta}*`);
+    lines.push('');
+    lines.push(item.desc);
+    lines.push('');
+    if (item.links.length) {
+      lines.push(item.links.map(l => `[${l.label}](${l.href})`).join(' · '));
+      lines.push('');
+    }
+  }
+
+  lines.push('## Experience');
+  lines.push('');
+  for (const job of experience) {
+    lines.push(`### ${job.company} · ${job.role}`);
+    lines.push('');
+    lines.push(`*${job.period} · ${job.location}*`);
+    lines.push('');
+    lines.push(job.description);
+    lines.push('');
+    if (job.tags.length) {
+      lines.push(`Tags: ${job.tags.join(', ')}`);
+      lines.push('');
+    }
+  }
+
+  lines.push('## Skills & Tools');
+  lines.push('');
+  for (const group of skillGroups) {
+    lines.push(`### ${group.label}`);
+    lines.push('');
+    lines.push(group.skills.map(s => `- ${s}`).join('\n'));
+    lines.push('');
+  }
+
+  if (talks.length) {
+    lines.push('## Talks & Writing');
+    lines.push('');
+    for (const talk of talks) {
+      lines.push(`### ${talk.title}`);
+      lines.push('');
+      lines.push(`*${talk.type} · ${talk.event} · ${talk.year}*`);
+      lines.push('');
+      if (talk.desc) {
+        lines.push(talk.desc);
+        lines.push('');
+      }
+      if (talk.links.length) {
+        lines.push(talk.links.map(l => `[${l.label}](${l.href})`).join(' · '));
+        lines.push('');
+      }
+    }
+  }
+
+  lines.push('## Education');
+  lines.push('');
+  lines.push('### University of Toledo');
+  lines.push('');
+  lines.push('Bachelor of Science, Computer Science Engineering Technology · 2010');
+  lines.push('');
+
+  lines.push('## Elsewhere');
+  lines.push('');
+  for (const s of socials) {
+    lines.push(`- [${s.label}](${s.href})`);
+  }
+  lines.push('');
+
+  return new Response(lines.join('\n'), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};


### PR DESCRIPTION
## Summary

- **Site bio + meta description**: drop the work-leading framing in favor of the builder/photographer/dad shape that matches the rest of the site.
- **Work page**: page-header copy, meta description, and `ProfilePage`+`Person` JSON-LD for search and LLM indexability. Experience entries updated to current scope (Security & Networking, no longer Migration).
- **Sensitivity scrub** on the 2020-2025 and 2019-2020 entries: removed internal AWS revenue/growth metrics, customer-identifying scale at named-industry level, and director-transition / open-rec detail.
- **New `/work.md`** companion route mirroring the post `.md` pattern, noindexed via `_headers`, referenced from `llms.txt`. Also dropped the Leica callout from the `llms.txt` bio paragraph.

## Test plan

- [x] `npx vitest run` — 235 passing
- [x] `npm run build` — 48 pages built, `/work.md` emits clean
- [x] Verified scrubbed metrics no longer appear in `dist/work.md`
- [ ] Spot-check `/work` and `/work.md` on the preview deploy